### PR TITLE
added link to navbar to rec page

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -49,6 +49,11 @@ export default function AppNavbar({
 
           <Navbar.Collapse className="justify-content-between">
             <Nav className="mr-auto">
+              {currentUser && currentUser.loggedIn && (
+                <Nav.Link as={Link} to="/requests/create">
+                  Request Recommendation
+                </Nav.Link>
+              )}
               {hasRole(currentUser, "ROLE_ADMIN") && (
                 <NavDropdown
                   title="Admin"

--- a/frontend/src/tests/components/Nav/AppNavbar.test.jsx
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.jsx
@@ -233,4 +233,59 @@ describe("AppNavbar tests", () => {
     expect(screen.queryByText("Completed Requests")).not.toBeInTheDocument();
     expect(screen.queryByText("Statistics")).not.toBeInTheDocument();
   });
+
+  test("renders Request Recommendation link for logged in users", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+    const doLogin = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Request Recommendation");
+    const requestLink = screen.getByText("Request Recommendation");
+    expect(requestLink).toBeInTheDocument();
+    expect(requestLink).toHaveAttribute("href", "/requests/create");
+  });
+
+  test("Request Recommendation link appears for professor users", async () => {
+    const currentUser = currentUserFixtures.professorUser;
+    const doLogin = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Request Recommendation");
+    const requestLink = screen.getByText("Request Recommendation");
+    expect(requestLink).toBeInTheDocument();
+  });
+
+  test("Request Recommendation link does not show when not logged in", async () => {
+    const currentUser = currentUserFixtures.notLoggedIn;
+    const systemInfo = systemInfoFixtures.showingBoth;
+    const doLogin = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByText("Request Recommendation")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/tests/components/Nav/AppNavbar.test.jsx
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.jsx
@@ -286,6 +286,8 @@ describe("AppNavbar tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.queryByText("Request Recommendation")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Request Recommendation"),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
closes #3 

I have added a link to the page to create a recommendation request from a particular professor to the navbar. solves issue #3 . the link routes to /requests/create, is only visible to logged in users, and displays "Recommendation Request" title. added three new tests in appnavbar.test to ensure that the link renders correctly and points to the correct page, and does not appear for non logged in users . deployed at https://rec-pr10.dokku-18.cs.ucsb.edu 