### PR TITLE
implemented loading of hardcoded request types at application startup

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/ExampleApplication.java
+++ b/src/main/java/edu/ucsb/cs156/rec/ExampleApplication.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.rec;
 
+import edu.ucsb.cs156.rec.services.RequestTypeService;
 import edu.ucsb.cs156.rec.services.wiremock.WiremockService;
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -20,6 +21,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 public class ExampleApplication {
 
   @Autowired WiremockService wiremockService;
+
+  @Autowired RequestTypeService requestTypeService;
 
   @Bean
   public DateTimeProvider utcDateTimeProvider() {
@@ -49,6 +52,7 @@ public class ExampleApplication {
   public ApplicationRunner developmentApplicationRunner() {
     return arg -> {
       log.info("development mode");
+      requestTypeService.loadRequestTypes();
       log.info("developmentApplicationRunner completed");
     };
   }

--- a/src/main/java/edu/ucsb/cs156/rec/ExampleApplication.java
+++ b/src/main/java/edu/ucsb/cs156/rec/ExampleApplication.java
@@ -22,7 +22,8 @@ public class ExampleApplication {
 
   @Autowired WiremockService wiremockService;
 
-  @Autowired RequestTypeService requestTypeService;
+  @Autowired(required = false)
+  RequestTypeService requestTypeService;
 
   @Bean
   public DateTimeProvider utcDateTimeProvider() {
@@ -52,7 +53,9 @@ public class ExampleApplication {
   public ApplicationRunner developmentApplicationRunner() {
     return arg -> {
       log.info("development mode");
-      requestTypeService.loadRequestTypes();
+      if (requestTypeService != null) {
+        requestTypeService.loadRequestTypes();
+      }
       log.info("developmentApplicationRunner completed");
     };
   }

--- a/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeService.java
+++ b/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeService.java
@@ -4,6 +4,8 @@ import edu.ucsb.cs156.rec.entities.RequestType;
 import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
 import java.util.Arrays;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -24,13 +26,23 @@ public class RequestTypeService {
           "PhD program",
           "Other");
 
+  /** Result class for loadRequestTypes method. */
+  @Data
+  @AllArgsConstructor
+  public static class LoadResult {
+    private int loaded;
+    private int skipped;
+  }
+
   /**
    * Load hardcoded request types into the database if they don't already exist.
    *
    * <p>This method checks for each hardcoded request type and only creates it if it's not already
    * in the database.
+   *
+   * @return LoadResult containing the number of types loaded and skipped
    */
-  public void loadRequestTypes() {
+  public LoadResult loadRequestTypes() {
     log.info("Loading hardcoded request types...");
     int loadedCount = 0;
     int skippedCount = 0;
@@ -48,5 +60,6 @@ public class RequestTypeService {
     }
 
     log.info("Request type loading completed. Loaded: {}, Skipped: {}", loadedCount, skippedCount);
+    return new LoadResult(loadedCount, skippedCount);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeService.java
+++ b/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeService.java
@@ -1,0 +1,52 @@
+package edu.ucsb.cs156.rec.services;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/** Service for managing Request Types. */
+@Service
+@Slf4j
+public class RequestTypeService {
+
+  @Autowired private RequestTypeRepository requestTypeRepository;
+
+  /** List of hardcoded request types to be loaded at startup. */
+  private static final List<String> HARDCODED_REQUEST_TYPES =
+      Arrays.asList(
+          "CS Department BS/MS program",
+          "Scholarship or Fellowship",
+          "MS program (other than CS Dept BS/MS)",
+          "PhD program",
+          "Other");
+
+  /**
+   * Load hardcoded request types into the database if they don't already exist.
+   *
+   * <p>This method checks for each hardcoded request type and only creates it if it's not already
+   * in the database.
+   */
+  public void loadRequestTypes() {
+    log.info("Loading hardcoded request types...");
+    int loadedCount = 0;
+    int skippedCount = 0;
+
+    for (String type : HARDCODED_REQUEST_TYPES) {
+      if (requestTypeRepository.findByRequestType(type).isEmpty()) {
+        RequestType requestType = RequestType.builder().requestType(type).build();
+        requestTypeRepository.save(requestType);
+        log.info("Loaded request type: {}", type);
+        loadedCount++;
+      } else {
+        log.debug("Request type already exists, skipping: {}", type);
+        skippedCount++;
+      }
+    }
+
+    log.info("Request type loading completed. Loaded: {}, Skipped: {}", loadedCount, skippedCount);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeServiceTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeServiceTest.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.rec.services;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,13 +28,15 @@ public class RequestTypeServiceTest {
     when(requestTypeRepository.findByRequestType(any(String.class))).thenReturn(Optional.empty());
 
     // Act
-    requestTypeService.loadRequestTypes();
+    RequestTypeService.LoadResult result = requestTypeService.loadRequestTypes();
 
     // Assert
     // Should save 5 request types: CS Department BS/MS program, Scholarship or Fellowship,
     // MS program (other than CS Dept BS/MS), PhD program, Other
     verify(requestTypeRepository, times(5)).save(any(RequestType.class));
     verify(requestTypeRepository, times(5)).findByRequestType(any(String.class));
+    assertEquals(5, result.getLoaded());
+    assertEquals(0, result.getSkipped());
   }
 
   @Test
@@ -52,12 +55,14 @@ public class RequestTypeServiceTest {
     when(requestTypeRepository.findByRequestType("Other")).thenReturn(Optional.of(existingType));
 
     // Act
-    requestTypeService.loadRequestTypes();
+    RequestTypeService.LoadResult result = requestTypeService.loadRequestTypes();
 
     // Assert
     // Should only save 3 new types (skipping "Scholarship or Fellowship" and "Other")
     verify(requestTypeRepository, times(3)).save(any(RequestType.class));
     verify(requestTypeRepository, times(5)).findByRequestType(any(String.class));
+    assertEquals(3, result.getLoaded());
+    assertEquals(2, result.getSkipped());
   }
 
   @Test
@@ -69,11 +74,13 @@ public class RequestTypeServiceTest {
         .thenReturn(Optional.of(existingType));
 
     // Act
-    requestTypeService.loadRequestTypes();
+    RequestTypeService.LoadResult result = requestTypeService.loadRequestTypes();
 
     // Assert
     // Should not save any types since all already exist
     verify(requestTypeRepository, times(0)).save(any(RequestType.class));
     verify(requestTypeRepository, times(5)).findByRequestType(any(String.class));
+    assertEquals(0, result.getLoaded());
+    assertEquals(5, result.getSkipped());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeServiceTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeServiceTest.java
@@ -1,0 +1,79 @@
+package edu.ucsb.cs156.rec.services;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RequestTypeServiceTest {
+
+  @Mock private RequestTypeRepository requestTypeRepository;
+
+  @InjectMocks private RequestTypeService requestTypeService;
+
+  @Test
+  public void test_loadRequestTypes_loadsAllTypesWhenNoneExist() {
+    // Arrange
+    when(requestTypeRepository.findByRequestType(any(String.class))).thenReturn(Optional.empty());
+
+    // Act
+    requestTypeService.loadRequestTypes();
+
+    // Assert
+    // Should save 5 request types: CS Department BS/MS program, Scholarship or Fellowship,
+    // MS program (other than CS Dept BS/MS), PhD program, Other
+    verify(requestTypeRepository, times(5)).save(any(RequestType.class));
+    verify(requestTypeRepository, times(5)).findByRequestType(any(String.class));
+  }
+
+  @Test
+  public void test_loadRequestTypes_skipsExistingTypes() {
+    // Arrange
+    RequestType existingType = RequestType.builder().id(1L).requestType("Other").build();
+
+    // Mock that some types exist and some don't
+    when(requestTypeRepository.findByRequestType("CS Department BS/MS program"))
+        .thenReturn(Optional.empty());
+    when(requestTypeRepository.findByRequestType("Scholarship or Fellowship"))
+        .thenReturn(Optional.of(existingType));
+    when(requestTypeRepository.findByRequestType("MS program (other than CS Dept BS/MS)"))
+        .thenReturn(Optional.empty());
+    when(requestTypeRepository.findByRequestType("PhD program")).thenReturn(Optional.empty());
+    when(requestTypeRepository.findByRequestType("Other")).thenReturn(Optional.of(existingType));
+
+    // Act
+    requestTypeService.loadRequestTypes();
+
+    // Assert
+    // Should only save 3 new types (skipping "Scholarship or Fellowship" and "Other")
+    verify(requestTypeRepository, times(3)).save(any(RequestType.class));
+    verify(requestTypeRepository, times(5)).findByRequestType(any(String.class));
+  }
+
+  @Test
+  public void test_loadRequestTypes_skipsAllWhenAllExist() {
+    // Arrange
+    RequestType existingType = RequestType.builder().id(1L).requestType("Some Type").build();
+
+    when(requestTypeRepository.findByRequestType(any(String.class)))
+        .thenReturn(Optional.of(existingType));
+
+    // Act
+    requestTypeService.loadRequestTypes();
+
+    // Assert
+    // Should not save any types since all already exist
+    verify(requestTypeRepository, times(0)).save(any(RequestType.class));
+    verify(requestTypeRepository, times(5)).findByRequestType(any(String.class));
+  }
+}


### PR DESCRIPTION
closes #2 

added automatic loading of hardcoded request types at startup. created RequestTypeService with 5 predefined types (CS Department BS/MS program, Scholarship or Fellowship, MS program, PhD program, Other) and a method that checks existing types before inserting. updated ExampleApplication.java to call the service in development mode. wrote unit tests to verify it loads new types, skips existing ones, and handles both cases. can verify by running mvn spring-boot:run and checking console logs or the H2 console at localhost:8080/h2-console as shown in this screenshot: 
<img width="404" height="377" alt="Screenshot 2025-11-24 at 3 15 43 PM" src="https://github.com/user-attachments/assets/ecc31d91-85e9-4db4-96fe-14f0a76e9282" />
solves issue #2 .deployed at https://rec-pr11.dokku-18.cs.ucsb.edu 