### PR TITLE
added create request type option on admin page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,6 +45,21 @@ function App() {
               path="/admin/requests"
               element={<AdminRequestsPage />}
             />
+            <Route
+              exact
+              path="/requesttypes/all"
+              element={<RequestTypeIndexPage />}
+            />
+            <Route
+              exact
+              path="/requesttypes/post"
+              element={<RequestTypeCreatePage />}
+            />
+            <Route
+              exact
+              path="/requesttypes/edit/:id"
+              element={<RequestTypeEditPage />}
+            />
           </>
         )}
         {(hasRole(currentUser, "ROLE_PROFESSOR") ||

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -59,6 +59,9 @@ export default function AppNavbar({
                   <NavDropdown.Item href="/admin/requests">
                     Requests
                   </NavDropdown.Item>
+                  <NavDropdown.Item href="/requesttypes/all">
+                    Request Types
+                  </NavDropdown.Item>
                 </NavDropdown>
               )}
               {hasRole(currentUser, "ROLE_PROFESSOR") && (

--- a/frontend/src/tests/components/Nav/AppNavbar.test.jsx
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.jsx
@@ -233,4 +233,20 @@ describe("AppNavbar tests", () => {
     expect(screen.queryByText("Completed Requests")).not.toBeInTheDocument();
     expect(screen.queryByText("Statistics")).not.toBeInTheDocument();
   });
+
+  test("admin dropdown renders for admin user", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+    const doLogin = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const adminDropdown = await screen.findByTestId("appnavbar-admin-dropdown");
+    expect(adminDropdown).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
added admin access to manage request types. updated App.jsx to include routes for admins to view, create, and edit request types at /requesttypes/all, /requesttypes/post, and /requesttypes/edit/:id. added "Request Types" link to the admin dropdown in AppNavbar.jsx so admins can access the request type management pages from the navbar. added test in AppNavbar.test.jsx to verify the admin dropdown renders corre
<img width="1179" height="169" alt="Screenshot 2025-11-24 at 4 48 25 PM" src="https://github.com/user-attachments/assets/565240fb-d01f-4ff8-a1e3-d8dbae539eed" />
<img width="756" height="249" alt="Screenshot 2025-11-24 at 4 48 37 PM" src="https://github.com/user-attachments/assets/dada22cb-1fcf-4b2f-931e-f7c33153a500" />
ctly. backend controller already had all CRUD operations with ROLE_ADMIN permissions and frontend pages already existed, so just needed to give admins access to the existing functionality. all 150 frontend tests and 94 backend tests pass. solves issue #4 . deployed at https://rec-pr12.dokku-18.cs.ucsb.edu